### PR TITLE
Update requirements-client.txt and requirements-server.txt

### DIFF
--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,7 +1,7 @@
 rich
 keyboard
 pyclip
-numpy
+numpy==1.26.4
 sounddevice
 websockets
 pypinyin

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -1,6 +1,6 @@
 rich
 websockets
-numpy
+numpy==1.26.4
 typeguard==2.13.3
 sherpa_onnx==1.8.11
 funasr_onnx==0.2.5


### PR DESCRIPTION
Loading the server models fails under the recent release of NumPy 2.0. This PR adds a specification on numpy version to solve this problem.