### PR TITLE
LLM功能增强，新增关键词指令功能

### DIFF
--- a/build-client.spec
+++ b/build-client.spec
@@ -64,6 +64,8 @@ hiddenimports += [
     'rich',
     'rich.console',
     'rich.markdown',
+    'rich._unicode_data',
+    'rich._unicode_data.unicode17-0-0', 
     'keyboard',
     'pyclip',
     'numpy',

--- a/build.spec
+++ b/build.spec
@@ -62,6 +62,8 @@ hiddenimports += [
     'rich',
     'rich.console',
     'rich.markdown',
+    'rich._unicode_data',
+    'rich._unicode_data.unicode17-0-0', 
     'keyboard',
     'pyclip',
     'numpy',

--- a/config_client.py
+++ b/config_client.py
@@ -32,6 +32,30 @@ class ClientConfig:
         },
     ]
 
+    # LLM 清除历史指令关键词（完全匹配）
+    # 支持一个或多个关键词：clear_history_keywords = ['清除历史', '清除记忆', '清除上下文'] ，留空则关闭此功能：clear_history_keywords = []
+    clear_history_keywords = ['清除历史', '清除记忆', '清除上下文']
+
+    # LLM 撤回上一轮对话的关键词（完全匹配）
+    # 支持一个或多个关键词：revoke_last_turn_keywords = ['撤回', '撤销', '回退'] ，留空则关闭此功能：revoke_last_turn_keywords = []
+    revoke_last_turn_keywords = ['撤回最近对话', '撤销最近对话', '回退最近对话']
+
+    # LLM 显示上一轮对话的关键词（完全匹配）
+    # 支持一个或多个关键词：show_last_turn_keywords = ['显示', '查看', '最近'] ，留空则关闭此功能：show_last_turn_keywords = []
+    show_last_turn_keywords = ['显示最近对话', '查看最近对话']
+
+    # LLM 复制全部上下文的关键词（完全匹配）
+    # 支持一个或多个关键词：copy_all_context_keywords = ['复制', '拷贝'] ，留空则关闭此功能：copy_all_context_keywords = []
+    copy_all_context_keywords = ['复制全部上下文', '拷贝全部上下文']
+
+    # LLM 复制当前角色上下文的关键词（完全匹配）
+    # 支持一个或多个关键词：copy_current_role_context_keywords = ['复制当前角色上下文', '拷贝当前角色上下文'] ，留空则关闭此功能：copy_current_role_context_keywords = []
+    copy_current_role_context_keywords = ['复制当前角色上下文', '拷贝当前角色上下文']
+
+    # LLM 复制结果的关键词（完全匹配）
+    # 支持一个或多个关键词：copy_result_keywords = ['复制结果', '复制输出'] ，留空则关闭此功能：copy_result_keywords = []
+    copy_result_keywords = ['复制最近结果', '复制输出']
+
     threshold    = 0.3          # 快捷键触发阈值（秒）
 
     paste        = False        # 是否以写入剪切板然后模拟 Ctrl-V 粘贴的方式输出结果

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -16,3 +16,6 @@ Pillow
 
 markdown
 tkhtmlview
+
+# 补充缺失报错
+tbb

--- a/util/client/startup.py
+++ b/util/client/startup.py
@@ -37,6 +37,42 @@ def _setup_tray(state, base_dir):
         from util.client.ui import toast
         toast("清除成功：已清除所有角色的对话历史记录", duration=3000, bg="#075077")
 
+    def revoke_last_turn():
+        from util.llm.llm_handler import revoke_last_turn
+        from util.client.ui import toast
+        success, message = revoke_last_turn()
+        if success:
+            toast(message, duration=3000, bg="#075077")
+        else:
+            toast(message, duration=3000, bg="#d9534f")
+
+    def show_last_turn():
+        from util.llm.llm_handler import show_last_turn
+        from util.client.ui import toast
+        success, message = show_last_turn()
+        if success:
+            toast(message, duration=5000, bg="#075077")
+        else:
+            toast(message, duration=3000, bg="#d9534f")
+
+    def copy_all_context():
+        from util.llm.llm_handler import copy_all_context
+        from util.client.ui import toast
+        success, message = copy_all_context()
+        if success:
+            toast(message, duration=3000, bg="#075077")
+        else:
+            toast(message, duration=3000, bg="#d9534f")
+
+    def copy_current_role_context():
+        from util.llm.llm_handler import copy_current_role_context
+        from util.client.ui import toast
+        success, message = copy_current_role_context()
+        if success:
+            toast(message, duration=3000, bg="#075077")
+        else:
+            toast(message, duration=3000, bg="#d9534f")
+
     def add_hotword():
         try:
             from util.client.ui import on_add_hotword
@@ -63,6 +99,11 @@ def _setup_tray(state, base_dir):
         if text:
             from util.llm.llm_clipboard import copy_to_clipboard
             copy_to_clipboard(text)
+            from util.client.ui import toast
+            toast("复制成功：已复制结果到剪贴板", duration=3000, bg="#075077")
+        else:
+            from util.client.ui import toast
+            toast("复制失败：没有可复制的内容", duration=3000, bg="#d9534f")
 
     import os
     icon_path = os.path.join(base_dir, 'assets', 'icon.ico')
@@ -76,6 +117,10 @@ def _setup_tray(state, base_dir):
             ('✨ 添加热词', add_hotword),
             ('🛠️ 添加纠错', add_rectify),
             ('🧹 清除记忆', clear_memory),
+            ('↩️ 撤回上一轮', revoke_last_turn),
+            ('💬 显示最近对话', show_last_turn),
+            ('📄 复制所有上下文', copy_all_context),
+            ('📑 复制当前角色上下文', copy_current_role_context),
             ('🔄 重启音频', restart_audio),
         ]
     )

--- a/util/llm/llm_role_detector.py
+++ b/util/llm/llm_role_detector.py
@@ -4,11 +4,20 @@ LLM 角色检测器
 功能：
 1. 检测文本是否匹配某个角色前缀
 2. 返回对应的角色配置和去除前缀后的文本
+3. 检测指令关键词（清除历史、撤回上一轮、显示上一轮、复制结果、复制全部上下文、复制当前角色上下文）
 """
 from typing import Tuple, Optional
 from util.llm.llm_role_config import RoleConfig
 from util.llm.llm_interfaces import IRoleLoader
 from . import logger
+from config import ClientConfig
+
+# 指令标记常量
+COMMAND_TOKEN = "__COMMAND__"
+
+# 常量定义
+PREFIX_STRIP_PUNCTUATION = '：，。？！,.?! '
+ROLE_SORT_KEY = lambda item: len(item[1].name)
 
 
 class RoleDetector:
@@ -20,10 +29,33 @@ class RoleDetector:
             role_loader: 角色加载器实例
         """
         self.role_loader = role_loader
+        # 缓存角色列表和排序结果
+        self._cached_roles = None
+        self._cached_roles_sorted = None
+        self._roles_hash = None
+
+    def _get_sorted_roles(self):
+        """获取排序后的角色列表（带缓存和变化检测）"""
+        current_roles = self.role_loader.get_roles()
+        # 使用角色名称列表的排序字符串作为哈希值（检测角色名称和配置变化）
+        current_hash = hash(','.join(sorted(current_roles.keys())))
+        
+        # 如果角色列表发生变化，清除缓存
+        if self._roles_hash != current_hash:
+            self._cached_roles = current_roles
+            self._cached_roles_sorted = sorted(
+                current_roles.items(),
+                key=ROLE_SORT_KEY,
+                reverse=True
+            )
+            self._roles_hash = current_hash
+            logger.debug("角色列表已更新，已刷新检测缓存")
+        
+        return self._cached_roles_sorted
 
     def detect(self, text: str) -> Tuple[Optional[RoleConfig], str]:
         """
-        检测文本是否匹配某个角色前缀
+        检测文本是否匹配某个角色前缀或指令关键词
 
         Args:
             text: 输入文本
@@ -32,26 +64,143 @@ class RoleDetector:
             (role_config, content) - role_config 是 RoleConfig 对象，
             content 是去除前缀后的文本
         """
-        # logger.debug(f"检测角色，输入文本: {text[:50]}...")
+        # ======================================================================
+        # --- 指令处理函数（提前定义，避免重复导入）---
+        # ======================================================================
+        
+        # 清除历史指令
+        def _execute_clear_history():
+            from util.llm.llm_handler import clear_llm_history
+            clear_llm_history()
+            logger.info(f"检测到清除指令 '{text}'，已清除所有角色的对话历史记录")
+            toast("清除成功：已清除所有角色的对话历史记录", duration=3000, bg="#075077")
 
-        for role_name, role_config in self.role_loader.get_roles().items():
-            if role_name == '默认':
+        # 撤回上一轮对话指令
+        def _execute_revoke_last_turn():
+            from util.llm.llm_handler import revoke_last_turn
+            success, message = revoke_last_turn()
+            if success:
+                logger.info(f"检测到撤回指令 '{text}'，{message}")
+                toast(message, duration=3000, bg="#075077")
+            else:
+                logger.warning(f"检测到撤回指令 '{text}'，{message}")
+                toast(message, duration=3000, bg="#d9534f")
+
+        # 显示最近对话指令
+        def _execute_show_last_turn():
+            from util.llm.llm_handler import show_last_turn
+            success, message = show_last_turn()
+            if success:
+                logger.info(f"检测到显示指令 '{text}'，{message}")
+                toast(message, duration=5000, bg="#075077")
+            else:
+                logger.warning(f"检测到显示指令 '{text}'，{message}")
+                toast(message, duration=3000, bg="#d9534f")
+
+        # 复制结果指令
+        def _execute_copy_result():
+            from util.client.state import get_state
+            from util.llm.llm_clipboard import copy_to_clipboard
+            state = get_state()
+            copy_text = state.last_output_text  # 使用新变量名，避免覆盖外层 text
+            if copy_text:
+                copy_to_clipboard(copy_text)
+                logger.info(f"检测到复制结果指令 '{text}'，已复制到剪贴板")
+                toast("复制成功：已复制结果到剪贴板", duration=3000, bg="#075077")
+            else:
+                logger.warning(f"检测到复制结果指令 '{text}'，但没有可复制的内容")
+                toast("复制失败：没有可复制的内容", duration=3000, bg="#d9534f")
+
+        # 复制全部上下文指令
+        def _execute_copy_all_context():
+            from util.llm.llm_handler import copy_all_context
+            success, message = copy_all_context()
+            if success:
+                logger.info(f"检测到复制全部上下文指令 '{text}'，{message}")
+                toast(message, duration=3000, bg="#075077")
+            else:
+                logger.warning(f"检测到复制全部上下文指令 '{text}'，{message}")
+                toast(message, duration=3000, bg="#d9534f")
+
+        # 复制当前角色上下文指令
+        def _execute_copy_current_role_context():
+            from util.llm.llm_handler import copy_current_role_context
+            success, message = copy_current_role_context()
+            if success:
+                logger.info(f"检测到复制当前角色上下文指令 '{text}'，{message}")
+                toast(message, duration=3000, bg="#075077")
+            else:
+                logger.warning(f"检测到复制当前角色上下文指令 '{text}'，{message}")
+                toast(message, duration=3000, bg="#d9534f")
+
+        # ======================================================================
+        # --- 指令定义（统一管理）---
+        # ======================================================================
+        
+        # 将关键词列表转换为集合（只需转换一次）
+        keyword_sets = {
+            'clear_history': set(ClientConfig.clear_history_keywords) if ClientConfig.clear_history_keywords else set(),
+            'revoke_last_turn': set(ClientConfig.revoke_last_turn_keywords) if ClientConfig.revoke_last_turn_keywords else set(),
+            'show_last_turn': set(ClientConfig.show_last_turn_keywords) if ClientConfig.show_last_turn_keywords else set(),
+            'copy_result': set(ClientConfig.copy_result_keywords) if ClientConfig.copy_result_keywords else set(),
+            'copy_all_context': set(ClientConfig.copy_all_context_keywords) if ClientConfig.copy_all_context_keywords else set(),
+            'copy_current_role_context': set(ClientConfig.copy_current_role_context_keywords) if ClientConfig.copy_current_role_context_keywords else set(),
+        }
+        
+        # 指令元数据
+        command_definitions = {
+            'clear_history': {
+                'keywords': keyword_sets['clear_history'],
+                'action': _execute_clear_history,
+            },
+            'revoke_last_turn': {
+                'keywords': keyword_sets['revoke_last_turn'],
+                'action': _execute_revoke_last_turn,
+            },
+            'show_last_turn': {
+                'keywords': keyword_sets['show_last_turn'],
+                'action': _execute_show_last_turn,
+            },
+            'copy_result': {
+                'keywords': keyword_sets['copy_result'],
+                'action': _execute_copy_result,
+            },
+            'copy_all_context': {
+                'keywords': keyword_sets['copy_all_context'],
+                'action': _execute_copy_all_context,
+            },
+            'copy_current_role_context': {
+                'keywords': keyword_sets['copy_current_role_context'],
+                'action': _execute_copy_current_role_context,
+            },
+        }
+
+        # ======================================================================
+        # --- 指令检测（单次查找，无嵌套 if-elif）---
+        # ======================================================================
+        
+        # 检测指令关键词（使用集合快速查找）
+        from util.client.ui import toast  # 提前导入 toast
+        for cmd_name, cmd_def in command_definitions.items():
+            if text in cmd_def['keywords']:
+                cmd_def['action']()
+                return None, COMMAND_TOKEN  # 返回指令标记
+
+        # 检测角色前缀
+        # 获取排序后的角色列表（使用缓存）
+        roles = self._get_sorted_roles()
+
+        for role_name, role_config in roles:
+            # 合并检查：统一处理默认角色和未启用匹配的角色
+            if role_name == RoleConfig.DEFAULT_ROLE_NAME or not role_config.match:
                 continue
 
-            # 检查是否启用前缀匹配
-            if not role_config.match:
-                continue
+            # 检查前缀匹配
+            if text.startswith(role_name):
+                remaining_text = text[len(role_name):]
+                remaining_text = remaining_text.lstrip(PREFIX_STRIP_PUNCTUATION).lstrip()
 
-            name = role_config.name
-            # 空名字和「默认」都不作为前缀匹配
-            if not name or name == '默认':
-                continue
-
-            if name and text.startswith(name):
-                remaining_text = text[len(name):]
-                remaining_text = remaining_text.lstrip('：，。,. ')
-
-                # logger.debug(f"匹配到角色: {name}, 去除前缀后: {remaining_text[:50]}...")
+                # logger.debug(f"匹配到角色: {role_name}, 去除前缀后: {remaining_text[:50]}...")
                 return role_config, remaining_text
 
         # 未匹配，使用默认角色
@@ -60,5 +209,6 @@ class RoleDetector:
             # logger.debug(f"未匹配到角色前缀，使用默认角色，处理: {default_role.process}")
             return default_role, text
 
+        # 未匹配到角色且默认角色不处理，返回原始文本
         # logger.debug("未匹配到角色且默认角色不处理，返回原始文本")
         return None, text


### PR DESCRIPTION
我自己使用的llm增强功能，现提交PR，内容如下：

1.新增关键词指令功能 2.新增LLM功能 3.优化角色代码逻辑与性能 4.为部分菜单功能也加入toast，直观显示结果。

关键词指令：当语音输入内容完全匹配关键词时触发对应功能，可以在config.py中修改或禁用。

新增LLM功能如下：清除历史、显示最近一轮对话、撤回最近一轮对话、复制全部上下文、复制当前角色上下文。便于使用角色功能。

以上功能支持关键词触发和客户端托盘菜单触发，并为原有的复制结果和清除历史功能增加了关键词指令支持。

角色功能支持缓存和长度优先级匹配。

其他：关键词指令带有标记，不覆盖上次结果，便于复制。

requirement增加'tbb'，hiddenimports增加    'rich._unicode_data','rich._unicode_data.unicode17-0-0'，解决本地打包时遇到的报错。

---

我用LLM生成了一个unidiff的说明文档：

# CapsWriter-Offline 修改说明文档

## 概述

本次修改共涉及 7 个文件，新增约 505 行代码，主要实现了 LLM 交互增强功能，包括对话历史管理、指令关键词触发、上下文复制等功能。

------

## 修改文件详情

### 1. `config.py`

**新增 LLM 指令关键词配置**

```python
clear_history_keywords = ['清除历史', '清除记忆', '清除上下文']
revoke_last_turn_keywords = ['撤回最近对话', '撤销最近对话', '回退最近对话']
show_last_turn_keywords = ['显示最近对话', '查看最近对话']
copy_all_context_keywords = ['复制全部上下文', '拷贝全部上下文']
copy_current_role_context_keywords = ['复制当前角色上下文', '拷贝当前角色上下文']
copy_result_keywords = ['复制最近结果', '复制输出']
```

------

### 2. `util/llm/llm_handler.py`

**核心功能实现**

| 新增方法                                                     | 功能描述                                 |
| :----------------------------------------------------------- | :--------------------------------------- |
| `revoke_last_turn()` | 撤回最近一次使用的角色的最近一轮对话     |
| `show_last_turn()` | 显示最近一次使用的角色的最近一轮对话     |
| `copy_all_context()` | 复制所有启用历史的角色的所有历史到剪贴板 |
| `copy_current_role_context()` | 复制最近使用的角色的上下文到剪贴板       |

**其他改动**：

- 新增 `last_used_role` 属性追踪最近使用的角色
- 处理 `COMMAND_TOKEN` 指令标记，不更新输出文本
- 便捷函数 `revoke_last_turn()`, `show_last_turn()`, `copy_all_context()`, `copy_current_role_context()`

------

### 3. `util/llm/llm_role_detector.py`

**指令检测与角色检测增强**

| 功能           | 描述                                                         |
| :------------- | :----------------------------------------------------------- |
| 指令关键词检测 | 支持 6 种指令的关键词检测（清除历史、撤回、显示、复制结果、复制全部上下文、复制当前角色上下文） |
| 角色缓存优化   | 添加角色列表缓存和变化检测机制                               |
| 统一指令处理   | 使用字典管理指令定义，避免嵌套 if-elif                       |

------

### 4. `util/client/startup.py`

**托盘菜单新增功能**

新增 4 个菜单项：

- **↩️ 撤回上一轮** - `revoke_last_turn()`
- **💬 显示最近对话** - `show_last_turn()`
- **📄 复制所有上下文** - `copy_all_context()`
- **📑 复制当前角色上下文** - `copy_current_role_context()`

**其他改动**：

- 添加复制成功/失败的 toast 提示

------

### 5. `build-client.spec` 和 `build.spec`

**打包依赖补充**

添加 `rich._unicode_data` 和 `rich._unicode_data.unicode17-0-0` 到 hiddenimports，解决 Rich 库 Unicode 数据加载问题。

------

### 6. `requirements-server.txt`

**依赖补充**

添加 `tbb` 依赖，解决打包时的缺失报错问题。

------

## 功能使用说明

### 指令关键词触发方式

用户可以在输入框中输入以下关键词触发功能：

| 功能               | 默认关键词                                       |
| :----------------- | :----------------------------------------------- |
| 清除历史           | `清除历史` / `清除记忆` / `清除上下文`           |
| 撤回上一轮         | `撤回最近对话` / `撤销最近对话` / `回退最近对话` |
| 显示最近对话       | `显示最近对话` / `查看最近对话`                  |
| 复制全部上下文     | `复制全部上下文` / `拷贝全部上下文`              |
| 复制当前角色上下文 | `复制当前角色上下文` / `拷贝当前角色上下文`      |
| 复制结果           | `复制最近结果` / `复制输出`                      |

### 托盘菜单触发方式

右键系统托盘图标，选择对应功能菜单项。

------

## 技术细节

**上下文复制格式规则**：

- 角色和内容之间增加换行
- 每两条（user+assistant）为一组
- 每组之间额外空一行（两个换行）
- 奇数组时，最后剩下的一条单独一组
- user 消息自动去除 "用户输入：" 前缀

**撤回规则**：

- 如果最后两条是 `[user, assistant]`，删除两者
- 如果只剩一条助手消息，删除助手消息