### PR TITLE
fix: 修复 display_name 未定义导致 LLM 默认角色仅生效一次

### DIFF
--- a/util/llm/llm_handler.py
+++ b/util/llm/llm_handler.py
@@ -204,7 +204,7 @@ class LLMHandler:
 
         return LLMResult(
             result=result,
-            role_name=display_name,
+            role_name=role_config.name or RoleConfig.DEFAULT_ROLE_NAME,
             processed=True,
             token_count=token_count,
             polish_time=time.time() - start_time,


### PR DESCRIPTION
## Summary
- `LLMHandler.process_and_output` 返回 `LLMResult` 时引用了未定义的 `display_name` 变量，导致 `NameError`
- 默认角色首次调用后异常冒泡终止 WebSocket 消息循环，后续识别结果不再被处理
- 将 `display_name` 替换为 `role_config.name or RoleConfig.DEFAULT_ROLE_NAME`，与同文件 `process()` 方法保持一致

## Test
- 配置 `LLM/default.py` 中 `process = True`，连续多次语音识别，确认每次都经过 LLM 润色