### PR TITLE
fix: 历史消息携带 timestamp 字段导致 API 400 错误

### DIFF
--- a/util/llm/llm_message_builder.py
+++ b/util/llm/llm_message_builder.py
@@ -72,7 +72,9 @@ class MessageBuilder:
 
         # 2. 对话历史
         if context_manager:
-            if hasattr(context_manager, 'history') and isinstance(context_manager.history, list):
+            if hasattr(context_manager, 'get_history') and callable(context_manager.get_history):
+                messages.extend(context_manager.get_history())
+            elif hasattr(context_manager, 'history') and isinstance(context_manager.history, list):
                 messages.extend(context_manager.history)
             elif isinstance(context_manager, list):
                 messages.extend(context_manager)


### PR DESCRIPTION
## Summary
- `ContextManager.add_message` 在历史消息中添加了 `timestamp` 字段
- `MessageBuilder.build_messages` 直接引用 `context_manager.history`，将 `timestamp` 一并发送给 API
- OpenAI 兼容接口不接受该字段，返回 400 错误
- 修复：优先调用 `get_history()` 方法，只返回 `role` 和 `content`

## Test
- 配置 `LLM/default.py` 中 `process = True` 且 `enable_history = True`，连续多次语音识别，确认第二句及之后不再报 400