### PR TITLE
feat: 录音时显示屏幕悬浮状态胶囊(声波+真实音量反应)

### DIFF
--- a/config_client.py
+++ b/config_client.py
@@ -42,6 +42,12 @@ class ClientConfig:
 
     save_audio = True           # 是否保存录音文件
     audio_name_len = 20         # 将录音识别结果的前多少个字存储到录音文件名中，建议不要超过200
+
+    show_recording_toast = True  # 录音时是否在屏幕上显示悬浮状态提示（深色胶囊+声波条），松开快捷键即消失
+    recording_toast_margin = 16  # 悬浮胶囊底边距任务栏的像素间距，越小越贴近任务栏
+    recording_toast_opacity = 0.88  # 悬浮胶囊整体不透明度（0.2~1.0），越小越透，背景透出越多
+    recording_toast_sensitivity = 12.0  # 波形对麦克风音量的灵敏度，说话时波形不够跳就调大、太满就调小
+    recording_toast_noise_gate = 0.010  # 噪声门：麦克风音量低于此值视为静音，没说话也在动就调大（如 0.02）
     
     context = ''                # 提示词上下文，用于辅助 Fun-ASR-Nano 模型识别（例如输入人名、地名、专业术语等）
     language = 'auto'           # 识别语言：'auto', 'chinese', 'english', 'japanese' 等（各引擎支持范围不同）

--- a/core/client/audio/stream.py
+++ b/core/client/audio/stream.py
@@ -78,6 +78,13 @@ class AudioStreamManager:
 
         import asyncio
 
+        # 只读采样：算一下本块的 RMS 电平，喂给悬浮胶囊做真实波形（不影响录音/识别）
+        try:
+            from core.ui.recording_level import set_level
+            set_level(float(np.sqrt(np.mean(np.square(indata)))))
+        except Exception:
+            pass
+
         # 将数据放入队列
         if self.app.loop and self.state.queue_in:
             asyncio.run_coroutine_threadsafe(

--- a/core/client/shortcut/task.py
+++ b/core/client/shortcut/task.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Optional
 
 from . import logger
 from core.tools.my_status import Status
+from core.client.ui.recording_toast import RecordingToast
  
 if TYPE_CHECKING:
     from core.client.shortcut.shortcut_config import Shortcut
@@ -58,6 +59,9 @@ class ShortcutTask:
         # 录音状态动画
         self._status = Status('开始录音', spinner='point')
 
+        # 录音状态悬浮提示（屏幕浮动条，可通过配置关闭）
+        self._rec_toast = RecordingToast()
+
     @property
     def state(self) -> ClientState:
         """快捷访问状态单例"""
@@ -89,6 +93,7 @@ class ShortcutTask:
 
         # 打印动画：正在录音
         self._status.start()
+        self._rec_toast.start()
 
         # 启动识别任务
         recorder = self._get_recorder()
@@ -104,6 +109,7 @@ class ShortcutTask:
         self.is_recording = False
         self.state.stop_recording()
         self._status.stop()
+        self._rec_toast.stop()
 
         self.task.cancel()
         self.task = None
@@ -115,6 +121,7 @@ class ShortcutTask:
         self.is_recording = False
         self.state.stop_recording()
         self._status.stop()
+        self._rec_toast.stop()
 
         asyncio.run_coroutine_threadsafe(
             self.state.queue_in.put({

--- a/core/client/ui/recording_toast.py
+++ b/core/client/ui/recording_toast.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+"""
+录音状态悬浮提示模块
+
+在录音期间于屏幕正中显示一个深色圆角胶囊（REC 红点 + 「正在聆听」+ 动态声波条），
+松开快捷键时立即消失。胶囊自身在 Tk 线程内驱动动画，本模块只负责开/关。
+
+与控制台的 spinner 动画（core.tools.my_status.Status）平行，互不影响，
+可通过 config_client.ClientConfig.show_recording_toast 开关。
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from config_client import ClientConfig as Config
+from . import logger
+
+
+_LABEL = '正在聆听'
+
+
+class RecordingToast:
+    """录音状态悬浮提示
+
+    每个快捷键任务持有一个独立实例，与 Status 控制台动画一一对应。
+    """
+
+    def __init__(self) -> None:
+        self._manager = None
+        self._msg_id: Optional[str] = None
+
+    def start(self) -> None:
+        """开始显示悬浮提示（若已显示则忽略）"""
+        if not Config.show_recording_toast:
+            return
+        if self._msg_id is not None:
+            return
+
+        try:
+            from core.ui.toast import ToastMessageManager, ToastMessage
+            from core.ui.recording_level import reset as reset_level
+
+            reset_level()  # 清掉上次录音残留的电平
+            self._manager = ToastMessageManager()
+            msg = ToastMessage(
+                text=_LABEL,
+                streaming=True,            # 常驻，不自动消失，直到 close
+                window_type='recording',
+            )
+            self._msg_id = self._manager.add_message(msg)
+            logger.debug('录音悬浮提示已显示')
+        except Exception as e:
+            logger.error(f'显示录音悬浮提示失败: {e}', exc_info=True)
+            self._manager = None
+            self._msg_id = None
+
+    def stop(self) -> None:
+        """关闭悬浮提示（若未显示则忽略）"""
+        if self._msg_id is None:
+            return
+        try:
+            if self._manager is not None:
+                self._manager.close_toast(self._msg_id)
+        except Exception as e:
+            logger.error(f'关闭录音悬浮提示失败: {e}', exc_info=True)
+        finally:
+            self._manager = None
+            self._msg_id = None
+            logger.debug('录音悬浮提示已关闭')

--- a/core/ui/recording_level.py
+++ b/core/ui/recording_level.py
@@ -1,0 +1,48 @@
+# coding: utf-8
+"""
+录音电平总线
+
+一个极简、线程安全、零项目依赖的共享通道：音频回调侧写入实时麦克风电平，
+录音悬浮胶囊侧读取以驱动波形。带时间戳，读取方可判断数据是否新鲜——
+不新鲜（如未录音、独立测试）时应回退到合成动画。
+
+写入：core.client.audio.stream._audio_callback（每 ~50ms 一次）
+读取：core.ui.toast_recording.ToastWindowRecording._tick（每帧）
+"""
+
+from __future__ import annotations
+
+import time
+import threading
+
+_lock = threading.Lock()
+_level = 0.0
+_ts = 0.0
+
+
+def set_level(level: float) -> None:
+    """写入最新电平（0.0~1.0 量级的 RMS/峰值，未归一化也可）。"""
+    global _level, _ts
+    with _lock:
+        _level = float(level)
+        _ts = time.time()
+
+
+def get_level(max_age: float = 0.25) -> tuple:
+    """读取电平。
+
+    Returns:
+        (level, fresh)。fresh=False 表示超过 max_age 秒无更新，
+        读取方应据此回退到合成动画。
+    """
+    with _lock:
+        fresh = (time.time() - _ts) <= max_age
+        return (_level if fresh else 0.0), fresh
+
+
+def reset() -> None:
+    """清零（在一次录音开始时调用，避免残留上次的电平）。"""
+    global _level, _ts
+    with _lock:
+        _level = 0.0
+        _ts = 0.0

--- a/core/ui/toast_manager.py
+++ b/core/ui/toast_manager.py
@@ -21,6 +21,7 @@ if __name__ == "__main__":
         sys.path.insert(0, project_root)
     from core.ui.toast_text import ToastWindowText
     from core.ui.toast_label import ToastWindowLabel
+    from core.ui.toast_recording import ToastWindowRecording
     from core.ui.toast_constants import (
         QUEUE_POLL_INTERVAL_MS,
         DEFAULT_DURATION_MS,
@@ -31,6 +32,7 @@ if __name__ == "__main__":
 else:
     from .toast_text import ToastWindowText
     from .toast_label import ToastWindowLabel
+    from .toast_recording import ToastWindowRecording
     from .toast_constants import (
         QUEUE_POLL_INTERVAL_MS,
         DEFAULT_DURATION_MS,
@@ -79,7 +81,7 @@ class ToastMessage:
     initial_width: Union[float, int] = DEFAULT_INITIAL_WIDTH
     initial_height: int = 0
     streaming: bool = False
-    window_type: Literal['text', 'label'] = 'text'
+    window_type: Literal['text', 'label', 'recording'] = 'text'
     stop_callback: Optional[Callable[[], None]] = None
     markdown: bool = False
     editable: bool = False  # Markdown 渲染后是否允许编辑
@@ -169,7 +171,12 @@ class ToastMessageManager:
                 msg_id = getattr(msg, '_id', 'unknown')
 
                 # 根据 window_type 选择窗口类
-                WindowClass = ToastWindowLabel if msg.window_type == 'label' else ToastWindowText
+                if msg.window_type == 'recording':
+                    WindowClass = ToastWindowRecording
+                elif msg.window_type == 'label':
+                    WindowClass = ToastWindowLabel
+                else:
+                    WindowClass = ToastWindowText
 
                 toast_window = WindowClass(
                     self.root,

--- a/core/ui/toast_recording.py
+++ b/core/ui/toast_recording.py
@@ -1,0 +1,375 @@
+# coding: utf-8
+"""
+录音状态指示胶囊窗口
+
+屏幕中下部（贴近任务栏）的深色圆角胶囊，左侧一颗呼吸的 REC 红点 + 文案，
+右侧一组有机跳动的声波条。用于录音期间提示「麦克风正在聆听」，无读秒。
+多显示器时出现在「光标所在的那块屏幕」，而非固定主屏。
+
+设计取向：
+    - 近黑胶囊 (#161618) + 轻微通透 (-alpha)，全圆角靠 -transparentcolor 抠出
+    - 唯一记忆点 = 右侧缓动跳动的声波条（像真实电平表）
+    - 动效克制：淡入 + 波形跳动 + 红点呼吸，仅此三样
+
+由 ToastMessageManager 在其 Tk 线程中创建，动画通过 window.after 驱动，
+close_toast 时销毁。
+"""
+
+from __future__ import annotations
+
+import math
+import random
+import tkinter as tk
+from typing import Optional, Callable, Union
+
+from .toast_constants import DEFAULT_FONT_FAMILY
+from .toast_logger import get_toast_logger
+
+logger = get_toast_logger(__name__)
+
+
+def _bottom_margin() -> int:
+    """胶囊底边距任务栏的像素间距
+
+    优先读取 config_client.ClientConfig.recording_toast_margin，
+    取不到（如非客户端环境）时用默认值 _BOTTOM_MARGIN。
+    """
+    try:
+        from config_client import ClientConfig
+        m = getattr(ClientConfig, 'recording_toast_margin', None)
+        if isinstance(m, (int, float)):
+            return int(m)
+    except Exception:
+        pass
+    return _BOTTOM_MARGIN
+
+
+def _level_gain() -> float:
+    """波形灵敏度（RMS→满幅增益），读 config，夹到 [1, 80]。"""
+    val = _LEVEL_GAIN
+    try:
+        from config_client import ClientConfig
+        m = getattr(ClientConfig, 'recording_toast_sensitivity', None)
+        if isinstance(m, (int, float)):
+            val = float(m)
+    except Exception:
+        pass
+    return max(1.0, min(80.0, val))
+
+
+def _level_gate() -> float:
+    """噪声门阈值（RMS），读 config，夹到 [0, 0.2]。"""
+    val = _LEVEL_GATE
+    try:
+        from config_client import ClientConfig
+        m = getattr(ClientConfig, 'recording_toast_noise_gate', None)
+        if isinstance(m, (int, float)):
+            val = float(m)
+    except Exception:
+        pass
+    return max(0.0, min(0.2, val))
+
+
+def _read_mic_level() -> tuple:
+    """读取实时麦克风电平 (level, fresh)；不可用时返回 (0.0, False) 以回退合成动画。"""
+    try:
+        from .recording_level import get_level
+        return get_level()
+    except Exception:
+        return 0.0, False
+
+
+def _target_alpha() -> float:
+    """胶囊整体不透明度
+
+    优先读取 config_client.ClientConfig.recording_toast_opacity，
+    取不到时用默认值 _ALPHA；结果夹到 [0.2, 1.0] 以保证可读与可见。
+    """
+    val = _ALPHA
+    try:
+        from config_client import ClientConfig
+        m = getattr(ClientConfig, 'recording_toast_opacity', None)
+        if isinstance(m, (int, float)):
+            val = float(m)
+    except Exception:
+        pass
+    return max(0.2, min(1.0, val))
+
+
+def _cursor_monitor_workarea() -> Optional[tuple]:
+    """返回光标所在显示器的工作区 (left, top, right, bottom)
+
+    工作区已自动排除任务栏；用于把胶囊放在焦点屏幕的底部而非固定主屏。
+    仅 Windows 有效，失败时返回 None 由调用方降级。
+    """
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        user32 = ctypes.windll.user32
+
+        pt = wintypes.POINT()
+        if not user32.GetCursorPos(ctypes.byref(pt)):
+            return None
+
+        MONITOR_DEFAULTTONEAREST = 2
+        hmon = user32.MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST)
+
+        class MONITORINFO(ctypes.Structure):
+            _fields_ = [
+                ('cbSize', wintypes.DWORD),
+                ('rcMonitor', wintypes.RECT),
+                ('rcWork', wintypes.RECT),
+                ('dwFlags', wintypes.DWORD),
+            ]
+
+        mi = MONITORINFO()
+        mi.cbSize = ctypes.sizeof(MONITORINFO)
+        if not user32.GetMonitorInfoW(hmon, ctypes.byref(mi)):
+            return None
+
+        w = mi.rcWork
+        return (w.left, w.top, w.right, w.bottom)
+    except Exception:
+        return None
+
+
+# ---- 设计 token ----------------------------------------------------------
+_CHROMA = '#010203'        # 透明抠图色（不会与任何绘制色撞色）
+_PILL_BG = '#14141a'       # 胶囊底色（近黑，微偏冷以配青）
+_PILL_STROKE = '#4a4a54'   # 玻璃边缘：半透明背景下用一道细边定住轮廓
+_TEXT_FG = '#f5f5f7'
+_DOT_HI = '#ff453a'        # REC 红点（亮）
+_DOT_LO = '#5c1a16'        # REC 红点（暗，用于呼吸插值）
+_ALPHA = 0.88              # 整体通透度（越小越透，文字仍需可读）
+
+# 签名元素：密集声条频谱（白→青渐变），中间高两侧低，带说话般起伏 + 横向流动
+_WAVE_C1 = '#f5f5f7'       # 声条左端色（近白）
+_WAVE_C2 = '#35e0d0'       # 声条右端色（青，签名色）
+_WAVE_W = 84               # 声条区域宽度（像素）
+_WAVE_AMP = 11             # 声条半振幅（像素，满幅约 2×）
+_WAVE_SPEED = 0.17         # 相位推进速度（每帧）
+_BAR_COUNT = 15            # 声条数量
+_BAR_W = 3                 # 单条宽度（像素，圆头）
+_BAR_MIN_H = 2             # 静止时的最小半高，避免消失
+
+# 真实电平驱动（拿不到实时电平时回退到合成动画）
+_LEVEL_GATE = 0.010        # 噪声门：RMS 低于此值视为静音（减掉底噪，避免没说话也在动）
+_LEVEL_GAIN = 12.0         # 过门后 RMS→满幅的增益（越大越灵敏，按麦克风口味调）
+_LEVEL_GAMMA = 0.6         # 感知曲线（<1 把小音量抬起来，正常说话就能填到大半）
+_LEVEL_ATTACK = 0.6        # 变响时的跟随速度（大=更跟手）
+_LEVEL_DECAY = 0.18        # 变弱时的回落速度（小=更平滑的余韵）
+_LEVEL_FLOOR = 0.06        # 静音时的基线高度占比（越小越贴平）
+
+_FONT_SIZE = 14
+_PILL_H = 50               # 胶囊高度（= 圆角直径）
+_PAD_X = 24                # 左右内边距（留出更宽松的边界）
+_DOT_R = 4.5               # 红点半径
+_GAP_DOT_TEXT = 12
+_GAP_TEXT_WAVE = 20
+
+_BOTTOM_MARGIN = 16        # 胶囊底边距任务栏（工作区底部）的像素间距
+
+_FRAME_MS = 40             # ~25fps
+_FADE_STEP = 0.16          # 每帧淡入增量
+
+
+class ToastWindowRecording:
+    """录音指示胶囊窗口
+
+    构造签名与 ToastWindowLabel / ToastWindowText 保持一致，便于
+    ToastMessageManager 统一实例化；多余参数忽略。
+    """
+
+    def __init__(
+        self,
+        parent_root: tk.Tk,
+        text: str,
+        font_size: int = _FONT_SIZE,
+        font_family: str = '',
+        bg: str = _PILL_BG,
+        fg: str = _TEXT_FG,
+        duration: int = 0,
+        initial_width: Union[float, int] = 0,
+        initial_height: int = 0,
+        streaming: bool = True,
+        stop_callback: Optional[Callable[[], None]] = None,
+        markdown: bool = False,
+        editable: bool = False,
+    ) -> None:
+        self.streaming = True          # 常驻，由 close_toast 销毁
+        self._text = text or '正在聆听'
+        self._font_family = font_family if font_family else DEFAULT_FONT_FAMILY
+        self._font_size = font_size or _FONT_SIZE
+        self._frame = 0
+        self._alpha = 0.0
+        self._target_alpha = _target_alpha()   # 淡入目标不透明度（读配置）
+        self._after_id: Optional[str] = None
+        self._level = 0.0              # 平滑后的真实电平（0~1）
+        self._gain = _level_gain()     # 灵敏度（读配置，创建时定）
+        self._gate = _level_gate()     # 噪声门（读配置，创建时定）
+        # 波形相位起点随机，避免每次录音从同一形状开始
+        self._phase0 = random.uniform(0, 6.283)
+        # 预算好每根声条的白→青颜色，避免每帧重复插值
+        self._wave_colors = [
+            self._lerp(_WAVE_C1, _WAVE_C2, i / (_BAR_COUNT - 1))
+            for i in range(_BAR_COUNT)
+        ]
+
+        self.window = tk.Toplevel(parent_root)
+        self.window.overrideredirect(True)
+        self.window.attributes('-topmost', True)
+        try:
+            self.window.attributes('-transparentcolor', _CHROMA)
+            self.window.attributes('-alpha', 0.0)   # 从透明开始淡入
+        except tk.TclError:
+            # 平台不支持透明属性时降级为不透明
+            self._alpha = self._target_alpha
+
+        self.window.configure(bg=_CHROMA)
+        self.window.pack_propagate(False)
+
+        # 测量文本，计算胶囊尺寸
+        from tkinter import font as tkfont
+        self._font = tkfont.Font(family=self._font_family, size=self._font_size)
+        text_w = self._font.measure(self._text)
+        self._w = int(round(_PAD_X + _DOT_R * 2 + _GAP_DOT_TEXT + text_w
+                            + _GAP_TEXT_WAVE + _WAVE_W + _PAD_X))
+        self._h = int(_PILL_H)
+
+        self.canvas = tk.Canvas(
+            self.window, width=self._w, height=self._h,
+            bg=_CHROMA, highlightthickness=0, bd=0,
+        )
+        self.canvas.pack(fill=tk.BOTH, expand=True)
+
+        # 定位：光标所在屏幕的底部居中，贴近任务栏
+        margin = _bottom_margin()
+        area = _cursor_monitor_workarea()
+        if area is not None:
+            left, top, right, bottom = area
+            x = int(left + (right - left - self._w) // 2)
+            y = int(bottom - self._h - margin)
+        else:
+            # 降级：主屏底部居中
+            sw = self.window.winfo_screenwidth()
+            sh = self.window.winfo_screenheight()
+            x = int((sw - self._w) // 2)
+            y = int(sh - self._h - margin - 48)
+        self.window.geometry(f'{self._w}x{self._h}+{x}+{y}')
+
+        # 预存布局坐标
+        self._dot_cx = _PAD_X + _DOT_R
+        self._text_x = self._dot_cx + _DOT_R + _GAP_DOT_TEXT
+        self._wave_x0 = self._text_x + text_w + _GAP_TEXT_WAVE
+        self._mid_y = self._h / 2
+
+        self._draw_static()
+        self.window.deiconify()
+        self._tick()
+
+    # -- 绘制 --------------------------------------------------------------
+    def _draw_static(self) -> None:
+        """绘制不变的部分：圆角胶囊底（含玻璃细边）+ 文案"""
+        # 内缩 1px，让描边不被画布裁掉；细边在半透明背景下定住胶囊轮廓
+        r = self._h / 2 - 1
+        self._round_rect(
+            1, 1, self._w - 1, self._h - 1, r,
+            fill=_PILL_BG, outline=_PILL_STROKE, width=1,
+        )
+        self.canvas.create_text(
+            self._text_x, self._mid_y, text=self._text, anchor='w',
+            fill=_TEXT_FG, font=self._font,
+        )
+
+    def _round_rect(self, x1, y1, x2, y2, r, **kw) -> None:
+        pts = [
+            x1 + r, y1, x2 - r, y1, x2, y1, x2, y1 + r,
+            x2, y2 - r, x2, y2, x2 - r, y2, x1 + r, y2,
+            x1, y2, x1, y2 - r, x1, y1 + r, x1, y1,
+        ]
+        self.canvas.create_polygon(pts, smooth=True, **kw)
+
+    def _tick(self) -> None:
+        """每帧：淡入 + 红点呼吸 + 波形跳动"""
+        try:
+            if not self.window.winfo_exists():
+                return
+        except tk.TclError:
+            return
+
+        self._frame += 1
+
+        # 淡入
+        if self._alpha < self._target_alpha:
+            self._alpha = min(self._target_alpha, self._alpha + _FADE_STEP)
+            try:
+                self.window.attributes('-alpha', self._alpha)
+            except tk.TclError:
+                pass
+
+        self.canvas.delete('dyn')
+
+        # 红点呼吸
+        pulse = (math.sin(self._frame * 0.16) + 1) / 2      # 0..1
+        dot_color = self._lerp(_DOT_LO, _DOT_HI, 0.35 + 0.65 * pulse)
+        rr = _DOT_R + pulse * 1.2
+        self.canvas.create_oval(
+            self._dot_cx - rr, self._mid_y - rr,
+            self._dot_cx + rr, self._mid_y + rr,
+            fill=dot_color, outline='', tags='dyn',
+        )
+
+        # 密集声条频谱：白→青渐变，中间高两侧低（env），横向流动（相位 p）
+        p = self._phase0 + self._frame * _WAVE_SPEED
+
+        # 整体响度：优先用真实麦克风电平（平滑：起快落慢），
+        # 拿不到新鲜电平时回退到合成的“说话般”起伏，保证独立运行/测试也有动效
+        raw, fresh = _read_mic_level()
+        if fresh:
+            # 噪声门：减掉底噪，静音时归零，避免没说话也在动
+            eff = raw - self._gate
+            eff = eff if eff > 0.0 else 0.0
+            target = min(1.0, eff * self._gain) ** _LEVEL_GAMMA
+            k = _LEVEL_ATTACK if target > self._level else _LEVEL_DECAY
+            self._level += (target - self._level) * k
+            speech = _LEVEL_FLOOR + (1.0 - _LEVEL_FLOOR) * self._level
+            # 纹理深度随响度：安静时几乎静止，说话时才活跃
+            depth = 0.15 + 0.85 * self._level
+        else:
+            speech = 0.32 + 0.68 * abs(math.sin(p * 0.9))
+            depth = 1.0
+        step = _WAVE_W / _BAR_COUNT
+        for i in range(_BAR_COUNT):
+            t = (i + 0.5) / _BAR_COUNT
+            env = math.sin(math.pi * t)                       # 中间高、两侧低
+            wave = 0.5 + 0.5 * math.sin(t * 11 - p * 3.2) * math.sin(t * 4 + p * 1.6)
+            detail = (1.0 - depth) + depth * wave             # depth 小→趋于静止
+            half = _WAVE_AMP * env * speech * detail
+            if half < _BAR_MIN_H:
+                half = _BAR_MIN_H
+            x = self._wave_x0 + (i + 0.5) * step
+            self.canvas.create_line(
+                x, self._mid_y - half, x, self._mid_y + half,
+                width=_BAR_W, fill=self._wave_colors[i],
+                capstyle=tk.ROUND, tags='dyn',
+            )
+
+        self._after_id = self.window.after(_FRAME_MS, self._tick)
+
+    # -- 工具 --------------------------------------------------------------
+    @staticmethod
+    def _lerp(c1: str, c2: str, t: float) -> str:
+        """在两个十六进制颜色间线性插值"""
+        t = max(0.0, min(1.0, t))
+        a = (int(c1[1:3], 16), int(c1[3:5], 16), int(c1[5:7], 16))
+        b = (int(c2[1:3], 16), int(c2[3:5], 16), int(c2[5:7], 16))
+        r = tuple(round(a[i] + (b[i] - a[i]) * t) for i in range(3))
+        return f'#{r[0]:02x}{r[1]:02x}{r[2]:02x}'
+
+    # 供 ToastMessageManager 兼容调用（本指示器不涉及文本流式更新）
+    def update_text(self, new_text: str) -> None:  # pragma: no cover - 兼容占位
+        pass
+
+    def set_text(self, new_text: str) -> None:     # pragma: no cover - 兼容占位
+        pass


### PR DESCRIPTION
给客户端加了一个**录音时的屏幕悬浮状态提示**：按住快捷键说话时，屏幕中下方（贴近任务栏、出现在光标所在的那块屏幕）淡入一个深色半透明圆角胶囊，左侧一颗 REC 红点 + 「正在聆听」，右侧一组**跟随真实麦克风音量起伏**的声波条；松开快捷键即消失。

原来录音时只有控制台里的转圈动画，黑窗口一旦隐藏就没有任何可见反馈。这个提示让「现在正在录音、麦克风确实听到声音了」变得一眼可见。

## 效果

<img width="362" height="84" alt="image" src="https://github.com/user-attachments/assets/bcc833ac-835d-44e7-9d3c-4fa0c0eeb5b8" />

## 实现方式

复用了项目现有的 Toast 悬浮窗体系，新增一个 `recording` 窗口类型，不改动任何现有 Toast 行为。

## 新增配置项

| 配置 | 作用 | 默认 |
|---|---|---|
| `show_recording_toast` | 总开关 | `True` |
| `recording_toast_margin` | 胶囊底边距任务栏的像素间距 | `16` |
| `recording_toast_opacity` | 整体不透明度（0.2~1.0） | `0.88` |
| `recording_toast_sensitivity` | 波形对音量的灵敏度 | `12.0` |
| `recording_toast_noise_gate` | 噪声门，低于此值视为静音 | `0.010` |

## 安全性 / 兼容性

- **不影响识别与录音**：音频回调里只多算了一次本块 RMS 并写入共享变量，整段用 `try/except` 包裹；数据流、发送、识别逻辑一行未改。
- **优雅降级**：拿不到实时电平时（例如非麦克风场景）波形自动回退到合成动画，不会卡死或报错。
- **纯增量**：原有控制台转圈动画与所有行为完全保留，本 PR 只做新增。
- **可一键关闭**：`show_recording_toast = False` 即完全禁用。


